### PR TITLE
chore: cozy-scripts is a dev dep only

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/drazik/cozy-music#readme",
   "devDependencies": {
     "babel-preset-cozy-app": "1.2.5",
-    "cozy-scripts": "^5",
+    "cozy-scripts": "5.4.2",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.9.1",
     "git-directory-deploy": "1.5.1",
@@ -44,7 +44,6 @@
   "dependencies": {
     "cozy-bar": "7.12.3",
     "cozy-client": "15.3.0",
-    "cozy-scripts": "5.4.2",
     "cozy-ui": "37.8.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",


### PR DESCRIPTION
Remove cozy-scripts in dependencies to keep it only as a dev dependency